### PR TITLE
chore: release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0](https://github.com/samp-reston/doip-definitions/compare/v2.0.0...v3.0.0) - 2025-02-10
+
+### Other
+
+- change generic into dyn
+
 ## [2.0.0](https://github.com/samp-reston/doip-definitions/compare/v1.0.3...v2.0.0) - 2025-02-09
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-definitions"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "A Diagnostics over Internet Protocol (DoIP) definition library for use in DoIP applications."


### PR DESCRIPTION



## 🤖 New release

* `doip-definitions`: 2.0.0 -> 3.0.0 (⚠ API breaking changes)

### ⚠ `doip-definitions` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type DoipMessage is no longer Send, in /tmp/.tmpJAcESQ/doip-definitions/src/doip_payload/message.rs:11
  type DoipMessage is no longer Sync, in /tmp/.tmpJAcESQ/doip-definitions/src/doip_payload/message.rs:11
  type DoipMessage is no longer Unpin, in /tmp/.tmpJAcESQ/doip-definitions/src/doip_payload/message.rs:11
  type DoipMessage is no longer UnwindSafe, in /tmp/.tmpJAcESQ/doip-definitions/src/doip_payload/message.rs:11
  type DoipMessage is no longer RefUnwindSafe, in /tmp/.tmpJAcESQ/doip-definitions/src/doip_payload/message.rs:11

--- failure sized_impl_removed: Sized no longer implemented ---

Description:
A public type is no longer Sized.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#sized
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/sized_impl_removed.ron

Failed in:
  type DoipMessage in /tmp/.tmpJAcESQ/doip-definitions/src/doip_payload/message.rs:11

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait doip_definitions::header::DoipPayload gained Debug in file /tmp/.tmpJAcESQ/doip-definitions/src/doip_header/payload_type.rs:17

--- failure type_allows_fewer_generic_type_params: type now allows fewer generic type parameters ---

Description:
A type now allows fewer generic type parameters than it used to. Uses of this type that supplied all previously-supported generic types will be broken.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/type_allows_fewer_generic_type_params.ron

Failed in:
  Struct DoipMessage allows 1 -> 0 generic types in /tmp/.tmpJAcESQ/doip-definitions/src/doip_payload/message.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.0](https://github.com/samp-reston/doip-definitions/compare/v2.0.0...v3.0.0) - 2025-02-10

### Other

- change generic into dyn
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).