### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/samp-reston/doip-definitions/compare/v1.0.3...v2.0.0) - 2025-02-10
+
+### Other
+
+- rollback version
+- add lifetime to message
+- release v3.0.0
+- change generic into dyn
+- release v2.0.0
+- update module name from message to payload
+- rename doip_message to doip_payload, remove version bytes transitions
+- removed all std-based impl, removed all bytes transitioning code to move to codec
+- make non-std changes
+
 ## [3.0.0](https://github.com/samp-reston/doip-definitions/compare/v2.0.0...v3.0.0) - 2025-02-10
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-definitions"
-version = "1.0.3"
+version = "2.0.0"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "A Diagnostics over Internet Protocol (DoIP) definition library for use in DoIP applications."


### PR DESCRIPTION



## 🤖 New release

* `doip-definitions`: 1.0.3 -> 2.0.0 (⚠ API breaking changes)

### ⚠ `doip-definitions` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_missing.ron

Failed in:
  enum doip_definitions::message::ActionCode, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/action_code.rs:8
  enum doip_definitions::message::ActivationType, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/activation_type.rs:8
  enum doip_definitions::error::AliveCheckResponseError, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:99
  enum doip_definitions::message::SyncStatus, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/sync_status.rs:8
  enum doip_definitions::error::EntityStatusResponseError, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:159
  enum doip_definitions::error::RoutingActivationResponseError, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:227
  enum doip_definitions::message::DiagnosticNackCode, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/diagnostic_nack.rs:7
  enum doip_definitions::error::DiagnosticMessageNackError, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:129
  enum doip_definitions::error::GenericNackError, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:176
  enum doip_definitions::error::VehicleAnnouncementMessageError, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:244
  enum doip_definitions::message::DiagnosticAckCode, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/diagnostic_ack.rs:7
  enum doip_definitions::message::NodeType, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/node_type.rs:9
  enum doip_definitions::message::ActivationCode, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/activation_code.rs:9
  enum doip_definitions::message::NackCode, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/nack_code.rs:8
  enum doip_definitions::error::ParseError, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:9
  enum doip_definitions::error::DiagnosticMessageAckError, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:112
  enum doip_definitions::error::PowerInformationResponseError, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:193
  enum doip_definitions::error::VehicleIdentificationRequestEidError, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:261
  enum doip_definitions::error::PayloadError, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:43
  enum doip_definitions::error::DiagnosticMessageError, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:146
  enum doip_definitions::error::RoutingActivationRequestError, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:210
  enum doip_definitions::error::VehicleIdentificationRequestVinError, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:274
  enum doip_definitions::message::PowerMode, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/power_mode.rs:6

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/inherent_method_missing.ron

Failed in:
  DoipHeader::new, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_header.rs:37
  DoipHeader::to_bytes, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_header.rs:47
  DoipVersion::to_u8, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_header/version.rs:51
  DoipVersion::from_u8, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_header/version.rs:56

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/module_missing.ron

Failed in:
  mod doip_definitions::message, previously in file /tmp/.tmp10oYYR/doip-definitions/src/lib.rs:44
  mod doip_definitions::error, previously in file /tmp/.tmp10oYYR/doip-definitions/src/error.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/struct_missing.ron

Failed in:
  struct doip_definitions::message::RoutingActivationResponse, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/routing_activation_response.rs:16
  struct doip_definitions::message::AliveCheckRequest, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/alive_check_request.rs:11
  struct doip_definitions::message::VehicleAnnouncementMessage, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/vehicle_announcement_message.rs:17
  struct doip_definitions::message::AliveCheckResponse, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/alive_check_response.rs:11
  struct doip_definitions::message::VehicleIdentificationRequest, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/vehicle_identification_request.rs:9
  struct doip_definitions::message::DiagnosticMessage, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/diagnostic_message.rs:13
  struct doip_definitions::message::VehicleIdentificationRequestEid, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/vehicle_identification_request_eid.rs:11
  struct doip_definitions::message::DiagnosticMessageAck, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/diagnostic_message_ack.rs:15
  struct doip_definitions::message::VehicleIdentificationRequestVin, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/vehicle_identification_request_vin.rs:11
  struct doip_definitions::message::DiagnosticMessageNack, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/diagnostic_message_nack.rs:15
  struct doip_definitions::message::EntityStatusRequest, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/entity_status_request.rs:8
  struct doip_definitions::message::EntityStatusResponse, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/entity_status_response.rs:17
  struct doip_definitions::message::GenericNack, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/generic_nack.rs:13
  struct doip_definitions::message::DoipMessage, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/message.rs:35
  struct doip_definitions::message::PowerInformationRequest, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/power_information_request.rs:8
  struct doip_definitions::message::PowerInformationResponse, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/power_information_response.rs:14
  struct doip_definitions::message::RoutingActivationRequest, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_message/routing_activation_request.rs:16

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/trait_method_missing.ron

Failed in:
  method to_bytes of trait DoipPayload, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_header/payload_type.rs:26
  method from_bytes of trait DoipPayload, previously in file /tmp/.tmp10oYYR/doip-definitions/src/doip_header/payload_type.rs:29
```

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).