### PR TITLE
chore: release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0](https://github.com/samp-reston/doip-definitions/compare/v2.0.1...v3.0.0) - 2025-02-26
+
+### Other
+
+- remove all encode decode
+- remove
+- remove encode decode
+- decision to move back to to/from_bytes
+- coverage
+- clippy fixes
+- attempt payload coverage
+- add tests for full coverage
+- remove old 3.0.0 notes
+- allow module name repetitions
+- added new consts to reduce lines of code
+- auto clippy fixes
+- implement from and try_from for all structs
+- move DoipPayload trait to base crate
+
+### Removed
+
+- removed bad docs
+
 ## [2.0.0](https://github.com/samp-reston/doip-definitions/compare/v1.0.3...v2.0.0) - 2025-02-10
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-definitions"
-version = "2.0.1"
+version = "3.0.0"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "A Diagnostics over Internet Protocol (DoIP) definition library for use in DoIP applications."


### PR DESCRIPTION



## 🤖 New release

* `doip-definitions`: 2.0.1 -> 3.0.0 (⚠ API breaking changes)

### ⚠ `doip-definitions` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_missing.ron

Failed in:
  enum doip_definitions::header::DoipVersion, previously in file /tmp/.tmpCAbKpa/doip-definitions/src/doip_header/version.rs:11

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/struct_missing.ron

Failed in:
  struct doip_definitions::payload::DoipMessage, previously in file /tmp/.tmpCAbKpa/doip-definitions/src/doip_payload/message.rs:11

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/trait_missing.ron

Failed in:
  trait doip_definitions::header::DoipPayload, previously in file /tmp/.tmpCAbKpa/doip-definitions/src/doip_header/payload_type.rs:17
```

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).