### PR TITLE
chore: release v3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.3](https://github.com/samp-reston/doip-definitions/compare/v3.0.2...v3.0.3) - 2025-03-02
+
+### Other
+
+- remove python build
+- chore add clone
+- add github test actions
+
 ## [3.0.2](https://github.com/samp-reston/doip-definitions/compare/v3.0.1...v3.0.2) - 2025-03-02
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-definitions"
-version = "3.0.2"
+version = "3.0.3"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "A Diagnostics over Internet Protocol (DoIP) definition library for use in DoIP applications."


### PR DESCRIPTION



## 🤖 New release

* `doip-definitions`: 3.0.2 -> 3.0.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.3](https://github.com/samp-reston/doip-definitions/compare/v3.0.2...v3.0.3) - 2025-03-02

### Other

- remove python build
- chore add clone
- add github test actions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).