### PR TITLE
chore: release v3.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.5](https://github.com/samp-reston/doip-definitions/compare/v3.0.4...v3.0.5) - 2025-05-10
+
+### Fixed
+
+- fix clippy lints
+
+### Other
+
+- add std support and organise module system
+
 ## [3.0.4](https://github.com/samp-reston/doip-definitions/compare/v3.0.3...v3.0.4) - 2025-03-04
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-definitions"
-version = "3.0.4"
+version = "3.0.5"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "A Diagnostics over Internet Protocol (DoIP) definition library for use in DoIP applications."


### PR DESCRIPTION



## 🤖 New release

* `doip-definitions`: 3.0.4 -> 3.0.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.5](https://github.com/samp-reston/doip-definitions/compare/v3.0.4...v3.0.5) - 2025-05-10

### Fixed

- fix clippy lints

### Other

- add std support and organise module system
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).