### PR TITLE
chore: release v3.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.8](https://github.com/samp-reston/doip-definitions/compare/v3.0.7...v3.0.8) - 2025-05-28
+
+### Other
+
+- build from and tryfrom traits, todo: test and validate
+
 ## [3.0.7](https://github.com/samp-reston/doip-definitions/compare/v3.0.6...v3.0.7) - 2025-05-10
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-definitions"
-version = "3.0.7"
+version = "3.0.8"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "A Diagnostics over Internet Protocol (DoIP) definition library for use in DoIP applications."


### PR DESCRIPTION



## 🤖 New release

* `doip-definitions`: 3.0.7 -> 3.0.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.8](https://github.com/samp-reston/doip-definitions/compare/v3.0.7...v3.0.8) - 2025-05-28

### Other

- build from and tryfrom traits, todo: test and validate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).