### PR TITLE
chore: release v3.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.10](https://github.com/samp-reston/doip-definitions/compare/v3.0.9...v3.0.10) - 2025-05-28
+
+### Other
+
+- expose error as pub mod
+
 ## [3.0.9](https://github.com/samp-reston/doip-definitions/compare/v3.0.8...v3.0.9) - 2025-05-28
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-definitions"
-version = "3.0.9"
+version = "3.0.10"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "A Diagnostics over Internet Protocol (DoIP) definition library for use in DoIP applications."


### PR DESCRIPTION



## 🤖 New release

* `doip-definitions`: 3.0.9 -> 3.0.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.10](https://github.com/samp-reston/doip-definitions/compare/v3.0.9...v3.0.10) - 2025-05-28

### Other

- expose error as pub mod
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).