### PR TITLE
chore: release v3.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.12](https://github.com/samp-reston/doip-definitions/compare/v3.0.11...v3.0.12) - 2025-06-26
+
+### Other
+
+- create sized buffer in Vec from DiagnosticMessage
+- decouple pyo3 bindings from std feature
+
 ## [3.0.11](https://github.com/samp-reston/doip-definitions/compare/v3.0.10...v3.0.11) - 2025-05-28
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-definitions"
-version = "3.0.11"
+version = "3.0.12"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "A Diagnostics over Internet Protocol (DoIP) definition library for use in DoIP applications."


### PR DESCRIPTION



## 🤖 New release

* `doip-definitions`: 3.0.11 -> 3.0.12

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.12](https://github.com/samp-reston/doip-definitions/compare/v3.0.11...v3.0.12) - 2025-06-26

### Other

- create sized buffer in Vec from DiagnosticMessage
- decouple pyo3 bindings from std feature
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).