### PR TITLE
Implement Builder Pattern for DoipMessages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,19 @@ pyo3 = { version = "0.24.2", features = [
 ], optional = true }
 
 [features]
-default = ["std"] # Enable std by default
-std = []    
-python-bindings = ["dep:pyo3", "std"] # Enable std and pyo3 when building for Python
+default = ["std", "builder"] # Enable std by default
+std = []
+python-bindings = [
+  "dep:pyo3",
+  "std",
+] # Enable std and pyo3 when building for Python
+builder = ["std"]
 
 [package.metadata]
-rust-analyzer = { checkOnSave.extraArgs = ["--check-cfg", "cfg(rust_analyzer)"] }
+rust-analyzer = { checkOnSave.extraArgs = [
+  "--check-cfg",
+  "cfg(rust_analyzer)",
+] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(rust_analyzer)"] }

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,0 +1,40 @@
+use crate::error::{Error, Result};
+use crate::payload;
+use crate::{header::DoipHeader, message::DoipMessage, payload::DoipPayload};
+
+#[derive(Default, Debug)]
+pub struct DoipMessageBuilder {
+    header: Option<DoipHeader>,
+    payload: Option<DoipPayload>,
+}
+
+impl DoipMessageBuilder {
+    pub fn new() -> Self {
+        DoipMessageBuilder::default()
+    }
+
+    pub fn header(&mut self, header: impl Into<DoipHeader>) -> &mut Self {
+        self.header = Some(header.into());
+        self
+    }
+
+    pub fn payload(&mut self, payload: impl Into<DoipPayload>) -> &mut Self {
+        self.payload = Some(payload.into());
+        self
+    }
+
+    fn build(&self) -> Result<DoipMessage> {
+        let Some(header) = self.header.as_ref() else {
+            return Err(Error::HeaderNotBuilt);
+        };
+
+        let Some(payload) = self.payload.as_ref() else {
+            return Err(Error::PayloadNotBuilt);
+        };
+
+        Ok(DoipMessage {
+            header: header.clone(),
+            payload: payload.clone(),
+        })
+    }
+}

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,40 +1,166 @@
-use crate::error::{Error, Result};
-use crate::payload;
+use crate::error::Result;
+use crate::header::{PayloadType, ProtocolVersion};
+use crate::payload::AliveCheckRequest;
 use crate::{header::DoipHeader, message::DoipMessage, payload::DoipPayload};
 
+/// A builder for constructing `DoipMessage` instances with specified headers and payloads.
+///
+/// This struct provides a fluent interface to configure the protocol version,
+/// payload, and automatically populate corresponding header fields based on the payload.
 #[derive(Default, Debug)]
 pub struct DoipMessageBuilder {
-    header: Option<DoipHeader>,
-    payload: Option<DoipPayload>,
+    /// The header portion of the DoIP message, containing metadata like protocol version and payload type.
+    header: DoipHeader,
+
+    /// The payload content of the DoIP message, which varies depending on the message type.
+    payload: DoipPayload,
+}
+
+impl Default for DoipPayload {
+    /// Provides a default payload of type `AliveCheckRequest`.
+    fn default() -> Self {
+        DoipPayload::AliveCheckRequest(AliveCheckRequest {})
+    }
+}
+
+impl Default for DoipHeader {
+    /// Constructs a default `DoipHeader` with:
+    /// - Protocol version set to `DefaultValue`
+    /// - Inverse protocol version calculated automatically
+    /// - Payload type set to `AliveCheckRequest`
+    /// - Payload length initialized to 0
+    fn default() -> Self {
+        Self {
+            protocol_version: ProtocolVersion::DefaultValue,
+            inverse_protocol_version: !(ProtocolVersion::DefaultValue as u8),
+            payload_type: PayloadType::AliveCheckRequest,
+            payload_length: Default::default(),
+        }
+    }
 }
 
 impl DoipMessageBuilder {
+    /// Creates a new `DoipMessageBuilder` instance using the default header and payload.
+    ///
+    /// # Example
+    /// ```
+    /// let builder = DoipMessageBuilder::new();
+    /// ```
     pub fn new() -> Self {
         DoipMessageBuilder::default()
     }
 
-    pub fn header(&mut self, header: impl Into<DoipHeader>) -> &mut Self {
-        self.header = Some(header.into());
+    /// Sets the protocol version in the header and updates the inverse protocol version accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `protocol_version` - An object that can be converted into a `ProtocolVersion`.
+    ///
+    /// # Returns
+    ///
+    /// The updated builder instance for chaining.
+    ///
+    /// # Example
+    /// ```
+    /// let builder = DoipMessageBuilder::new().protocol_version(ProtocolVersion::V1);
+    /// ```
+    pub fn protocol_version(mut self, protocol_version: impl Into<ProtocolVersion>) -> Self {
+        self.header.protocol_version = protocol_version.into();
+        self.header.inverse_protocol_version = !(self.header.protocol_version as u8);
         self
     }
 
-    pub fn payload(&mut self, payload: impl Into<DoipPayload>) -> &mut Self {
-        self.payload = Some(payload.into());
+    /// Sets the payload of the message and updates the header's payload type and length accordingly.
+    ///
+    /// # Arguments
+    ///
+    /// * `payload` - An object that can be converted into a `DoipPayload`.
+    ///
+    /// # Returns
+    ///
+    /// The updated builder instance for chaining.
+    ///
+    /// # Example
+    /// ```
+    /// let builder = DoipMessageBuilder::new().payload(DoipPayload::AliveCheckRequest(...));
+    /// ```
+    pub fn payload(mut self, payload: impl Into<DoipPayload>) -> Self {
+        self.payload = payload.into();
+
+        let (payload_type, size) = match self.payload {
+            DoipPayload::GenericNack(ref pay) => (PayloadType::GenericNack, size_of_val(pay)),
+            DoipPayload::VehicleIdentificationRequest(ref pay) => {
+                (PayloadType::VehicleIdentificationRequest, size_of_val(pay))
+            }
+            DoipPayload::VehicleIdentificationRequestEid(ref pay) => (
+                PayloadType::VehicleIdentificationRequestEid,
+                size_of_val(pay),
+            ),
+            DoipPayload::VehicleIdentificationRequestVin(ref pay) => (
+                PayloadType::VehicleIdentificationRequestVin,
+                size_of_val(pay),
+            ),
+            DoipPayload::VehicleAnnouncementMessage(ref pay) => {
+                (PayloadType::VehicleAnnouncementMessage, size_of_val(pay))
+            }
+            DoipPayload::RoutingActivationRequest(ref pay) => {
+                (PayloadType::RoutingActivationRequest, size_of_val(pay))
+            }
+            DoipPayload::RoutingActivationResponse(ref pay) => {
+                (PayloadType::RoutingActivationResponse, size_of_val(pay))
+            }
+            DoipPayload::AliveCheckRequest(ref pay) => {
+                (PayloadType::AliveCheckRequest, size_of_val(pay))
+            }
+            DoipPayload::AliveCheckResponse(ref pay) => {
+                (PayloadType::AliveCheckResponse, size_of_val(pay))
+            }
+            DoipPayload::EntityStatusRequest(ref pay) => {
+                (PayloadType::EntityStatusRequest, size_of_val(pay))
+            }
+            DoipPayload::EntityStatusResponse(ref pay) => {
+                (PayloadType::EntityStatusResponse, size_of_val(pay))
+            }
+            DoipPayload::PowerInformationRequest(ref pay) => {
+                (PayloadType::PowerInformationRequest, size_of_val(pay))
+            }
+            DoipPayload::PowerInformationResponse(ref pay) => {
+                (PayloadType::PowerInformationResponse, size_of_val(pay))
+            }
+            DoipPayload::DiagnosticMessage(ref pay) => {
+                (PayloadType::DiagnosticMessage, size_of_val(pay))
+            }
+            DoipPayload::DiagnosticMessageAck(ref pay) => {
+                (PayloadType::DiagnosticMessageAck, size_of_val(pay))
+            }
+            DoipPayload::DiagnosticMessageNack(ref pay) => {
+                (PayloadType::DiagnosticMessageNack, size_of_val(pay))
+            }
+        };
+
+        self.header.payload_type = payload_type;
+        self.header.payload_length = size as u32;
+
         self
     }
 
-    fn build(&self) -> Result<DoipMessage> {
-        let Some(header) = self.header.as_ref() else {
-            return Err(Error::HeaderNotBuilt);
-        };
-
-        let Some(payload) = self.payload.as_ref() else {
-            return Err(Error::PayloadNotBuilt);
-        };
-
+    /// Finalizes the builder and returns the constructed `DoipMessage`.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the fully constructed `DoipMessage` on success.
+    ///
+    /// # Example
+    /// ```
+    /// let message = DoipMessageBuilder::new()
+    ///     .payload(DoipPayload::AliveCheckRequest(...))
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn build(self) -> Result<DoipMessage> {
         Ok(DoipMessage {
-            header: header.clone(),
-            payload: payload.clone(),
+            header: self.header,
+            payload: self.payload,
         })
     }
 }

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -43,6 +43,7 @@ impl DoipMessageBuilder {
     ///
     /// # Example
     /// ```
+    /// use doip_definitions::builder::DoipMessageBuilder;
     /// let builder = DoipMessageBuilder::new();
     /// ```
     #[must_use]
@@ -62,7 +63,9 @@ impl DoipMessageBuilder {
     ///
     /// # Example
     /// ```
-    /// let builder = DoipMessageBuilder::new().protocol_version(ProtocolVersion::V1);
+    /// use doip_definitions::builder::DoipMessageBuilder;
+    /// use doip_definitions::header::ProtocolVersion;
+    /// let builder = DoipMessageBuilder::new().protocol_version(ProtocolVersion::Iso13400_2012);\
     /// ```
     #[must_use]
     pub fn protocol_version(mut self, protocol_version: impl Into<ProtocolVersion>) -> Self {
@@ -89,6 +92,11 @@ impl DoipMessageBuilder {
     ///
     /// # Example
     /// ```
+    /// use doip_definitions::builder::DoipMessageBuilder;
+    /// use doip_definitions::header::PayloadType;
+    /// use doip_definitions::payload::AliveCheckRequest;
+    /// use doip_definitions::payload::DoipPayload;
+    ///
     /// let builder = DoipMessageBuilder::new().payload(DoipPayload::AliveCheckRequest(AliveCheckRequest {}));
     /// ```
     #[must_use]
@@ -161,8 +169,13 @@ impl DoipMessageBuilder {
     ///
     /// # Example
     /// ```
+    /// use doip_definitions::builder::DoipMessageBuilder;
+    /// use doip_definitions::header::PayloadType;
+    /// use doip_definitions::payload::AliveCheckRequest;
+    /// use doip_definitions::payload::DoipPayload;
+    ///
     /// let message = DoipMessageBuilder::new()
-    ///     .payload(DoipPayload::AliveCheckRequest(...))
+    ///     .payload(DoipPayload::AliveCheckRequest(AliveCheckRequest {}))
     ///     .build();
     /// ```
     #[must_use]

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -65,7 +65,7 @@ impl DoipMessageBuilder {
     /// ```
     /// use doip_definitions::builder::DoipMessageBuilder;
     /// use doip_definitions::header::ProtocolVersion;
-    /// let builder = DoipMessageBuilder::new().protocol_version(ProtocolVersion::Iso13400_2012);\
+    /// let builder = DoipMessageBuilder::new().protocol_version(ProtocolVersion::Iso13400_2012);
     /// ```
     #[must_use]
     pub fn protocol_version(mut self, protocol_version: impl Into<ProtocolVersion>) -> Self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,11 @@ pub type Result<T> = core::result::Result<T, Error>;
 /// with context.
 #[derive(Debug, From)]
 pub enum Error {
+    /// When utilising the builder pattern the payload is not present
+    PayloadNotBuilt,
+    /// When utilising the builder pattern the header is not present
+    HeaderNotBuilt,
+
     /// Errors when accessing a range out of the slices scope.
     OutOfBounds {
         /// Source struct

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,55 @@ pub mod message {
     pub use crate::doip_message::DoipMessage;
 }
 
+/// # DoIP Message Builder Library
+///
+/// This module provides functionality to construct Diagnostic over IP (DoIP) messages used in automotive diagnostics
+/// in accordance with ISO 13400 standards.
+///
+/// It includes a builder pattern implementation (`DoipMessageBuilder`) that allows users to configure and construct
+/// valid `DoipMessage` instances with appropriate protocol headers and payloads. The builder ensures that metadata
+/// such as payload type and length are automatically derived from the provided payload content.
+///
+/// ## Features
+///
+/// - Typed and extensible `DoipPayload` variants for different message types
+/// - Automatic header field population (e.g., inverse protocol version, payload length)
+/// - Fluent, chainable builder interface
+/// - Safe default values for rapid prototyping
+///
+/// ## Example Usage
+///
+/// ```rust
+/// use your_crate_name::DoipMessageBuilder;
+/// use your_crate_name::payloads::AliveCheckRequest;
+/// use your_crate_name::DoipPayload;
+///
+/// let message = DoipMessageBuilder::new()
+///     .protocol_version(ProtocolVersion::V1)
+///     .payload(DoipPayload::AliveCheckRequest(AliveCheckRequest {}))
+///     .build()
+///     .expect("Failed to build DoIP message");
+/// ```
+///
+/// ## Message Types Supported
+///
+/// - Alive Check (Request/Response)
+/// - Vehicle Identification (Generic, EID, VIN)
+/// - Vehicle Announcement
+/// - Routing Activation (Request/Response)
+/// - Entity Status (Request/Response)
+/// - Power Information (Request/Response)
+/// - Diagnostic Messages (Standard, ACK, NACK)
+///
+/// ## Intended Usage
+///
+/// This library is designed for integration into vehicle diagnostics applications,
+/// simulation tools, or any system that needs to generate or send valid DoIP messages over a network.
+///
+/// ## Compliance
+///
+/// The design adheres to the structural requirements defined in ISO 13400 and aims to maintain
+/// compatibility with UDS-on-IP diagnostic stacks and OEM-specific DoIP implementations.
 #[cfg(feature = "builder")]
 pub mod builder;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,15 +115,15 @@ pub mod message {
 /// ## Example Usage
 ///
 /// ```rust
-/// use doip_definitions::DoipMessageBuilder;
-/// use doip_definitions::payloads::AliveCheckRequest;
-/// use doip_definitions::DoipPayload;
+/// use doip_definitions::builder::DoipMessageBuilder;
+/// use doip_definitions::payload::AliveCheckRequest;
+/// use doip_definitions::payload::DoipPayload;
+/// use doip_definitions::header::ProtocolVersion;
 ///
 /// let message = DoipMessageBuilder::new()
-///     .protocol_version(ProtocolVersion::V1)
+///     .protocol_version(ProtocolVersion::Iso13400_2012)
 ///     .payload(DoipPayload::AliveCheckRequest(AliveCheckRequest {}))
-///     .build()
-///     .expect("Failed to build DoIP message");
+///     .build();
 /// ```
 ///
 /// ## Message Types Supported

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,9 +96,9 @@ pub mod message {
     pub use crate::doip_message::DoipMessage;
 }
 
-/// # DoIP Message Builder Library
+/// # `DoIP` Message Builder Library
 ///
-/// This module provides functionality to construct Diagnostic over IP (DoIP) messages used in automotive diagnostics
+/// This module provides functionality to construct Diagnostic over IP (`DoIP`) messages used in automotive diagnostics
 /// in accordance with ISO 13400 standards.
 ///
 /// It includes a builder pattern implementation (`DoipMessageBuilder`) that allows users to configure and construct
@@ -115,9 +115,9 @@ pub mod message {
 /// ## Example Usage
 ///
 /// ```rust
-/// use your_crate_name::DoipMessageBuilder;
-/// use your_crate_name::payloads::AliveCheckRequest;
-/// use your_crate_name::DoipPayload;
+/// use doip_definitions::DoipMessageBuilder;
+/// use doip_definitions::payloads::AliveCheckRequest;
+/// use doip_definitions::DoipPayload;
 ///
 /// let message = DoipMessageBuilder::new()
 ///     .protocol_version(ProtocolVersion::V1)
@@ -139,12 +139,12 @@ pub mod message {
 /// ## Intended Usage
 ///
 /// This library is designed for integration into vehicle diagnostics applications,
-/// simulation tools, or any system that needs to generate or send valid DoIP messages over a network.
+/// simulation tools, or any system that needs to generate or send valid `DoIP` messages over a network.
 ///
 /// ## Compliance
 ///
 /// The design adheres to the structural requirements defined in ISO 13400 and aims to maintain
-/// compatibility with UDS-on-IP diagnostic stacks and OEM-specific DoIP implementations.
+/// compatibility with UDS-on-IP diagnostic stacks and OEM-specific `DoIP` implementations.
 #[cfg(feature = "builder")]
 pub mod builder;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,9 @@ pub mod message {
     pub use crate::doip_message::DoipMessage;
 }
 
+#[cfg(feature = "builder")]
+pub mod builder;
+
 // endregion:      --- Modules
 
 // Python bindings (only available when python-bindings is enabled)


### PR DESCRIPTION
Added the implementation of a builder pattern for DoipMessages allowing for the builder to handle inverse payload, payload type, and payload length logic under the hood saving line space within utilising code.