### PR TITLE
add no_alloc to no_std cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // region:      --- Configs
 #![cfg_attr(not(feature = "std"), no_std)] // Use no_std when the "std" feature is disabled
+#![cfg_attr(not(feature = "std"), no_alloc)] // Use no_alloc when the "std" feature is disabled
 #![warn(clippy::pedantic)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_docs)]


### PR DESCRIPTION
In addition to no_std I am adding no_alloc to continue down the path of hypersupport for embedded environments